### PR TITLE
fixing the logic of subdir creation in file_path

### DIFF
--- a/destest.py
+++ b/destest.py
@@ -67,8 +67,9 @@ def file_path( params, subdir, name, var=None, var2=None, var3=None, ftype='txt'
             raise IOError('Output directory already exists. Set output_exists to True to use existing output directory at your own peril.')
     else:
         if not os.path.exists(fpath):
+       	    os.mkdir(fpath)
+        if not os.path.exists(os.path.join(params['output'],params['param_file'][:params['param_file'].index('.')])) :
             os.mkdir(os.path.join(params['output'],params['param_file'][:params['param_file'].index('.')]))
-        os.mkdir(fpath)
         params['output_exists'] = True
 
     return os.path.join(fpath,name)


### PR DESCRIPTION
I cloned the destest repo and tried to run with the example "destest.yaml", changing the h5 file to the DES-Y3 subsample file (which I have a copy in Fermilab). It did work until I fix the logic in the creation of the 'subdir' in the file_path.   